### PR TITLE
Added support for GPS Present in flash

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -83,7 +83,7 @@
 								<option id="com.ti.ccstudio.buildDefinitions.MSP430_4.4.hex.ROMWIDTH.812572444" name="Specify rom width (--romwidth, -romwidth)" superClass="com.ti.ccstudio.buildDefinitions.MSP430_4.4.hex.ROMWIDTH" value="8" valueType="string"/>
 								<option id="com.ti.ccstudio.buildDefinitions.MSP430_4.4.hex.MEMWIDTH.1064499743" name="Specify memory width (--memwidth, -memwidth)" superClass="com.ti.ccstudio.buildDefinitions.MSP430_4.4.hex.MEMWIDTH" value="8" valueType="string"/>
 								<option id="com.ti.ccstudio.buildDefinitions.MSP430_4.4.hex.TOOL_ENABLE.1036664783" name="Enable tool" superClass="com.ti.ccstudio.buildDefinitions.MSP430_4.4.hex.TOOL_ENABLE" value="true" valueType="boolean"/>
-								<option id="com.ti.ccstudio.buildDefinitions.MSP430_4.4.hex.OUTPUT_FORMAT.255387911" superClass="com.ti.ccstudio.buildDefinitions.MSP430_4.4.hex.OUTPUT_FORMAT" value="com.ti.ccstudio.buildDefinitions.MSP430_4.4.hex.OUTPUT_FORMAT.TI_TXT" valueType="enumerated"/>
+								<option id="com.ti.ccstudio.buildDefinitions.MSP430_4.4.hex.OUTPUT_FORMAT.255387911" name="Output format" superClass="com.ti.ccstudio.buildDefinitions.MSP430_4.4.hex.OUTPUT_FORMAT" value="com.ti.ccstudio.buildDefinitions.MSP430_4.4.hex.OUTPUT_FORMAT.TI_TXT" valueType="enumerated"/>
 							</tool>
 						</toolChain>
 					</folderInfo>

--- a/.project
+++ b/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>Faraday_REVD1_Bringup</name>
+	<name>Faraday_D1_Release</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/Applications/Command/command.c
+++ b/Applications/Command/command.c
@@ -236,6 +236,9 @@ void app_command_parse(unsigned char *packet, unsigned char source){
 				AppMessageExperimentalPut(packet_parsed.payload, packet_parsed.payload_len);
 				break;
 
+			case 253: //RESET HARD CONFIG 0's
+				reset_hard();
+
 			case 254:
 				//Factory Reset device configuration
 				app_device_config_load_default();

--- a/Applications/Device_Config/Device_Config.c
+++ b/Applications/Device_Config/Device_Config.c
@@ -247,3 +247,7 @@ void app_device_config_device_debug_increment_char(unsigned char offset){
 	//Save incremented bootup counter
 	flash_write_info_c_segment_char(offset, buf_value);
 }
+
+void reset_hard(){
+	flash_erase_segment(FLASH_MEM_ADR_INFO_D);
+}

--- a/Applications/Device_Config/Device_Config.h
+++ b/Applications/Device_Config/Device_Config.h
@@ -263,4 +263,6 @@ void app_device_config_device_debug_increment_int(unsigned char offset);
  */
 void app_device_config_device_debug_increment_char(unsigned char offset);
 
+void reset_hard();
+
 #endif /* APPLICATIONS_DEVICE_CONFIG_DEVICE_CONFIG_H_ */

--- a/Applications/Device_Config/Device_Config.h
+++ b/Applications/Device_Config/Device_Config.h
@@ -77,6 +77,7 @@
 //Bitmask locations
 #define UNIT_PROGRAMMED BIT0 /**< Flash programmed configuration bitmask location */
 #define GPS_BOOT_ENABLE BIT0 /**< GPS boot enabled GPS boot bitmask location */
+#define GPS_PRESENT_BIT BIT1 /**< GPS boot enabled GPS boot bitmask location */
 #define UART_BEACON_BOOT_ENABLE BIT0 /**< UART beacon telemetry enabled telemetry boot bitmask location */
 #define RF_BEACON_BOOT_ENABLE BIT1 /**< RF beacon telemetry enabled telemetry boot bitmask */
 /** @}*/

--- a/Applications/Telemetry/Telemetry.c
+++ b/Applications/Telemetry/Telemetry.c
@@ -45,8 +45,6 @@
 #include "../Device_Config/Device_Config.h"
 
 
-
-
 /** @name Telemetry Application FIFO Variables
 *
 * 	These variables define the FIFO buffers to be used to enable the telemetry application
@@ -181,15 +179,34 @@ void application_telem_create_rf_pkt(unsigned char *packet, char *src_callsign, 
 		telem_packet_3_struct.rtc_year = RTC.year;
 
 		//Obtain GPS information
-		memcpy(&telem_packet_3_struct.gps_lattitude,(char *)GGA.Lat,9);
-		memcpy(&telem_packet_3_struct.gps_lattitude_dir,(char *)GGA.Lat_Dir,1);
-		memcpy(&telem_packet_3_struct.gps_longitude,(char *)GGA.Long,10);
-		memcpy(&telem_packet_3_struct.gps_longitude_dir,(char *)GGA.Long_Dir,1);
-		memcpy(&telem_packet_3_struct.gps_altitude,(char *)GGA.Altitude,8);
-		memcpy(&telem_packet_3_struct.gps_altitude_units,(char *)GGA.Alt_Units,1);
-		memcpy(&telem_packet_3_struct.gps_speed,(char *)RMC.Speed,5);
-		memcpy(&telem_packet_3_struct.gps_fix,(char *)GGA.Fix_Quality,1);
-		memcpy(&telem_packet_3_struct.gps_hdop,(char *)GGA.HDOP,4);
+		if(check_bitmask(gps_boot_bitmask, GPS_PRESENT_BIT)){
+			//GPS is present per FLASH configuration
+			memcpy(&telem_packet_3_struct.gps_lattitude,(char *)GGA.Lat,9);
+			memcpy(&telem_packet_3_struct.gps_lattitude_dir,(char *)GGA.Lat_Dir,1);
+			memcpy(&telem_packet_3_struct.gps_longitude,(char *)GGA.Long,10);
+			memcpy(&telem_packet_3_struct.gps_longitude_dir,(char *)GGA.Long_Dir,1);
+			memcpy(&telem_packet_3_struct.gps_altitude,(char *)GGA.Altitude,8);
+			memcpy(&telem_packet_3_struct.gps_altitude_units,(char *)GGA.Alt_Units,1);
+			memcpy(&telem_packet_3_struct.gps_speed,(char *)RMC.Speed,5);
+			memcpy(&telem_packet_3_struct.gps_fix,(char *)GGA.Fix_Quality,1);
+			memcpy(&telem_packet_3_struct.gps_hdop,(char *)GGA.HDOP,4);
+		}
+		else{
+			//GPS is NOT present per FLASH configuration
+			memcpy(&telem_packet_3_struct.gps_lattitude,(char *)default_lattitde,9);
+			memcpy(&telem_packet_3_struct.gps_lattitude_dir,(char *)default_lattitude_dir,1);
+			memcpy(&telem_packet_3_struct.gps_longitude,(char *)default_longitude,10);
+			memcpy(&telem_packet_3_struct.gps_longitude_dir,(char *)default_longitude_dir,1);
+			memcpy(&telem_packet_3_struct.gps_altitude,(char *)default_altitude,8);
+			memcpy(&telem_packet_3_struct.gps_altitude_units,(char *)default_altitude_units,1);
+			unsigned char speed[5] = {0,0,0,0,0};
+			memcpy(&telem_packet_3_struct.gps_speed,speed,5);
+			unsigned char fix_quality[1] = {0};
+			memcpy(&telem_packet_3_struct.gps_fix,(char *)fix_quality,1);
+			unsigned char hdop[4] = {0,0,0,0};
+			memcpy(&telem_packet_3_struct.gps_hdop,(char *)hdop,4);
+		}
+
 
 		//GPIO and System State
 		telem.IO_State	= 0x00;

--- a/Faraday_Init.c
+++ b/Faraday_Init.c
@@ -190,7 +190,7 @@ void init_UCS(void){
 	UCSCTL1 = DCORSEL_7;                // Select DCO range 16MHz operation
 	UCSCTL2 = FLLD_1 + 487;             // Set DCO Multiplier for 16MHz
 										// (N + 1) * FLLRef = Fdco
-										// (487 + 1) * 32768 = 16MHz (REFOCLK = internal 32768Hz)
+										// (487 + 1) * 32768 = 16MHz (15,990.8 MHz) (REFOCLK = internal 32768Hz)
 										// Set FLL Div = fDCOCLK/2
 	UCSCTL3 |= SELREF_2 + FLLREFDIV_0;  // Set DCO FLL reference = REF0CLK/1
 

--- a/HAL/GPIO.c
+++ b/HAL/GPIO.c
@@ -24,10 +24,9 @@
 *
 @{**/
 volatile unsigned char gpio_p3_guard = GPS_RESET + GPS_STANDBY + LED_1 + LED_2; /**< Guard bitmask for Port 3 */
-volatile unsigned char gpio_p4_guard = GPIO_0 + GPIO_1 + GPIO_2 + GPIO_3 + GPIO_4 + GPIO_5 + GPIO_6 + GPIO_7; /**< Guard bitmask for Port 4 */
+volatile unsigned char gpio_p4_guard = PA_ENABLE + LNA_ENABLE + HGM_SELECT + GPIO_3 + GPIO_4 + GPIO_5 + GPIO_6 + GPIO_7; /**< Guard bitmask for Port 4 */
 volatile unsigned char gpio_p5_guard = ARDUINO_IO_8 + ARDUINO_IO_9; /**< Guard bitmask for Port 3 */
 /** @}*/
-
 
 void gpio_update(unsigned char port, unsigned char pins, unsigned char command){
 	switch(port){

--- a/HAL/GPIO.c
+++ b/HAL/GPIO.c
@@ -75,25 +75,25 @@ void gpio_command_update(unsigned char *port, unsigned char channel, unsigned ch
 
 
 void CC1190_PA_Enable(void){
-	P3OUT |= PA_ENABLE;
+	P4OUT |= PA_ENABLE;
 }
 
 void CC1190_PA_Disable(void){
-	P3OUT &= ~PA_ENABLE;
+	P4OUT &= ~PA_ENABLE;
 }
 
 void CC1190_LNA_Enable(void){
-	P3OUT |= LNA_ENABLE;
+	P4OUT |= LNA_ENABLE;
 }
 
 void CC1190_LNA_Disable(void){
-	P3OUT &= ~LNA_ENABLE;
+	P4OUT &= ~LNA_ENABLE;
 }
 
 void CC1190_HGM_Enable(void){
-	P3OUT |= HGM_SELECT;
+	P4OUT |= HGM_SELECT;
 }
 
 void CC1190_HGM_Disable(void){
-	P3OUT &= ~HGM_SELECT;
+	P4OUT &= ~HGM_SELECT;
 }

--- a/HAL/GPIO.c
+++ b/HAL/GPIO.c
@@ -23,7 +23,7 @@
 *
 *
 @{**/
-volatile unsigned char gpio_p3_guard = GPS_RESET + GPS_STANDBY + LED_1 + LED_2; /**< Guard bitmask for Port 3 */
+volatile unsigned char gpio_p3_guard = GPIO_0 + GPIO_1 + GPIO_2 + GPS_RESET + GPS_STANDBY + LED_1 + LED_2; /**< Guard bitmask for Port 3 */
 volatile unsigned char gpio_p4_guard = PA_ENABLE + LNA_ENABLE + HGM_SELECT + GPIO_3 + GPIO_4 + GPIO_5 + GPIO_6 + GPIO_7; /**< Guard bitmask for Port 4 */
 volatile unsigned char gpio_p5_guard = ARDUINO_IO_8 + ARDUINO_IO_9; /**< Guard bitmask for Port 3 */
 /** @}*/

--- a/HAL/gps.c
+++ b/HAL/gps.c
@@ -11,8 +11,12 @@
 /* standard includes */
 #include "cc430f6137.h"
 #include "gps.h"
+#include "../REVA_Faraday.h"
 #include <string.h>
 #include <stdio.h>
+
+
+
 
 
 void initialize_GPS_structs(void){
@@ -46,6 +50,8 @@ void initialize_GPS_structs(void){
 	memset((void *)RMC.Mag_Dir,'0',sizeof(RMC.Mag_Dir));
 	memset((void *)RMC.Mode,'0',sizeof(RMC.Mode));
 	memset((void *)RMC.Checksum,'0',sizeof(RMC.Checksum));
+
+
 
 }
 
@@ -200,6 +206,18 @@ void Parse_GGA(volatile unsigned char *string){
 	while(string[++i] != '*'){
 		GGA.DGPS_Station[j] = string[i];
 		j++;
+	}
+
+	//Check if GPS has valid lock, turn on LED_1 if YES, turn off if NO.
+	// Valid is Fix_Quality of ASCII > 0, this means hex 0x31 or higher is a locked signal
+	gpsTest = GGA.Fix_Quality[0];
+	__no_operation();
+	if(gpsTest > 0x30){
+		__no_operation();
+		P3OUT |= LED_1;
+	}
+	else if (gpsTest <= 0x30){
+		P3OUT &= ~LED_1;
 	}
 }
 

--- a/HAL/gps.c
+++ b/HAL/gps.c
@@ -16,9 +16,6 @@
 #include <stdio.h>
 
 
-
-
-
 void initialize_GPS_structs(void){
 	memset((void *)GGA.Sync,'0',sizeof(GGA.Sync));
 	memset((void *)GGA.Time,'0',sizeof(GGA.Time));

--- a/HAL/gps.c
+++ b/HAL/gps.c
@@ -212,13 +212,16 @@ void Parse_GGA(volatile unsigned char *string){
 	// Valid is Fix_Quality of ASCII > 0, this means hex 0x31 or higher is a locked signal
 	gpsTest = GGA.Fix_Quality[0];
 	__no_operation();
-	if(gpsTest > 0x30){
+	/*if(gpsTest > 0x30){
 		__no_operation();
 		P3OUT |= LED_1;
+		P3OUT &= ~LED_2;
 	}
 	else if (gpsTest <= 0x30){
 		P3OUT &= ~LED_1;
+		P3OUT |= LED_2;
 	}
+	*/
 }
 
 

--- a/HAL/gps.h
+++ b/HAL/gps.h
@@ -147,4 +147,7 @@ void Parse_GGA(volatile unsigned char *string);
  */
 void Parse_RMC(volatile unsigned char *string);
 
+
+volatile unsigned char gpsTest; //GPS Testing, DEBUG
+
 #endif /* FARADAY_REVA_RF_MERGE_HAL_GPS_H_ */

--- a/housekeeping.c
+++ b/housekeeping.c
@@ -48,19 +48,6 @@ void main_housekeeping_routine(void){
 		//Check housekeeping functions
 		check_housekeeping();
 
-		if(gpsTest > 0x30){
-				__no_operation();
-				P3OUT |= LED_1;
-				P3OUT &= ~LED_2;
-			}
-			else if (gpsTest <= 0x30){
-				P3OUT &= ~LED_1;
-				P3OUT |= LED_2;
-			}
-
-
-
-
 	}
 }
 

--- a/housekeeping.c
+++ b/housekeeping.c
@@ -80,12 +80,12 @@ void housekeeping_check_raw(){
 		housekeeping_timer_count_1hz++;
 	}
 
-	if(CC430_Check_Transmitting_Flag()){
-		P3OUT |= LED_2;
-	}
-	else{
-		P3OUT &= ~LED_2;
-	}
+//	if(CC430_Check_Transmitting_Flag()){
+//		P3OUT |= LED_2;
+//	}
+//	else{
+//		P3OUT &= ~LED_2;
+//	}
 }
 
 

--- a/housekeeping.c
+++ b/housekeeping.c
@@ -40,11 +40,26 @@
 /* faraday application - high altitude balloon */
 #include "Applications/HAB/App_HAB.h"
 
+#include "HAL/gps.h"
+
 void main_housekeeping_routine(void){
 	if(housekeeping_bitmask_char & BIT0){
 		housekeeping_bitmask_char &= ~BIT0; //Disable general housekeeping bit
 		//Check housekeeping functions
 		check_housekeeping();
+
+		if(gpsTest > 0x30){
+				__no_operation();
+				P3OUT |= LED_1;
+				P3OUT &= ~LED_2;
+			}
+			else if (gpsTest <= 0x30){
+				P3OUT &= ~LED_1;
+				P3OUT |= LED_2;
+			}
+
+
+
 
 	}
 }

--- a/main.c
+++ b/main.c
@@ -48,12 +48,6 @@ int main(void) {
 	initialize_GPS_structs();
 	init_timer_A0(); //Enable main housekeeping timer
 
-	//Test GPIO
-	P3OUT |= LED_1 | LED_2;
-	__delay_cycles(1500000);
-	P3OUT &= ~LED_1;
-	P3OUT &= ~LED_2;
-
 
     //Applications
 	application_telemetry_initialize();
@@ -103,6 +97,19 @@ int main(void) {
     //Or enable Housekeeping flag, disable LPM, run through while(1) loop
     //and then reenable LPM?
 	///////////////////////////////////////////
+
+    /* Visual Boot GPIO Flash Sequence */
+    // Blink 1
+    gpio_update(3, LED_1 | LED_2, 1); // Turn both LED's ON
+	__delay_cycles(1000000); // Delay ON
+	gpio_update(3, LED_1 | LED_2, 0); // Turn both LED's OFF
+	__delay_cycles(1500000); // Delay OFF
+
+	//Blink 2
+	gpio_update(3, LED_1 | LED_2, 1); // Turn both LED's ON
+	__delay_cycles(1000000); // Delay ON
+	gpio_update(3, LED_1 | LED_2, 0); // Turn both LED's OFF
+	__delay_cycles(1500000); // Delay OFF
 
 
     //Scratch testing

--- a/main.c
+++ b/main.c
@@ -43,8 +43,16 @@ int main(void) {
 	app_device_config_load_default(); //Load defaults from flash
 	faraday_main_intialize();
 	init_GPS();
+	Faraday_GPS_Reset_Disable(); //DEBUG!
+	Faraday_GPS_Standby_Disable(); //DEBUG!
 	initialize_GPS_structs();
 	init_timer_A0(); //Enable main housekeeping timer
+
+	//Test GPIO
+	P3OUT |= LED_1 | LED_2;
+	__delay_cycles(1500000);
+	P3OUT &= ~LED_1;
+	P3OUT &= ~LED_2;
 
 
     //Applications

--- a/main.c
+++ b/main.c
@@ -111,9 +111,7 @@ int main(void) {
 	gpio_update(3, LED_1 | LED_2, 0); // Turn both LED's OFF
 	__delay_cycles(1500000); // Delay OFF
 
-
-    //Scratch testing
-    //flash_test(); // FLASH
+	/* Begin main loop */
 
     //Note: Per Errata bug the LPM iterrupt return will corrupt the PC, disable LPM when debugging and let the loop loose!
      while(1){


### PR DESCRIPTION
FLASH now supports a bit that can be queried to determine the presence of a GPS device or not by default. Telemetry packet was update to use default FLASH location data when no GPS present (due to this bit only).