### PR TITLE
Bug 69 - RF MAC Layer Broadcast Callsign Incorrect

### DIFF
--- a/Applications/Telemetry/Telem_RF.c
+++ b/Applications/Telemetry/Telem_RF.c
@@ -225,7 +225,7 @@ void app_telem_rf_housekeeping(void){
 			RF_L2_source_callsign[i] = app_packet_rf_config_buf[1+i];
 		}
 
-		for(i=0; i<RF_L2_source_callsign_len;i++){
+		for(i=0; i<RF_L2_destination_callsign_len;i++){
 			RF_L2_destination_callsign[i] = app_packet_rf_config_buf[9+i];
 		}
 

--- a/Version.h
+++ b/Version.h
@@ -17,6 +17,6 @@
 #ifndef VERSION_H_
 #define VERSION_H_
 
-const unsigned long firmware_revision = 0xdd84a31; //
+const unsigned long firmware_revision = 0xc1489a4; //
 
 #endif /* VERSION_H_ */


### PR DESCRIPTION
Bug 69 caused RF telemetry to not broadcast the correct destination callsign when a local device was programmed with a local callsign of length less that 6 characters. This caused RF transmissions to occur but reception to fail. Symptoms are noted as complete failure to receive RF telemetry.

Bug first reported by @reillyeon and confirmed that this update fixed his problems. 